### PR TITLE
Fixes #37;

### DIFF
--- a/src/main/java/com/mrcrayfish/controllable/Controllable.java
+++ b/src/main/java/com/mrcrayfish/controllable/Controllable.java
@@ -86,6 +86,8 @@ public class Controllable extends ControllerAdapter
         MinecraftForge.EVENT_BUS.register(input = new ControllerInput());
         MinecraftForge.EVENT_BUS.register(new RenderEvents());
         MinecraftForge.EVENT_BUS.register(new GuiEvents(Controllable.manager));
+
+        mc.mouseHelper = new ControllableMouseHelper(mc);
     }
 
     @Override

--- a/src/main/java/com/mrcrayfish/controllable/client/ControllableMouseHelper.java
+++ b/src/main/java/com/mrcrayfish/controllable/client/ControllableMouseHelper.java
@@ -1,0 +1,88 @@
+package com.mrcrayfish.controllable.client;
+
+import com.mrcrayfish.controllable.Controllable;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.MouseHelper;
+import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
+
+public class ControllableMouseHelper extends MouseHelper {
+
+    private final MouseHelper oldHelper;
+
+    public ControllableMouseHelper(Minecraft mc) {
+        super(mc);
+        oldHelper = mc.mouseHelper;
+    }
+
+    @Override
+    public void registerCallbacks(long handle) {
+        oldHelper.registerCallbacks(handle);
+    }
+
+    @Override
+    public void updatePlayerLook() {
+        super.updatePlayerLook();
+    }
+
+    @Override
+    public boolean isLeftDown() {
+        return super.isLeftDown();
+    }
+
+    @Override
+    public boolean isRightDown() {
+        return super.isRightDown();
+    }
+
+    @Override
+    public boolean isMiddleDown() {
+        return super.isMiddleDown();
+    }
+
+    @Override
+    public double getMouseX() {
+        return super.getMouseX();
+    }
+
+    @Override
+    public double getMouseY() {
+        return super.getMouseY();
+    }
+
+    @Override
+    public double getXVelocity() {
+        return super.getXVelocity();
+    }
+
+    @Override
+    public double getYVelocity() {
+        return super.getYVelocity();
+    }
+
+    @Override
+    public void setIgnoreFirstMove() {
+        super.setIgnoreFirstMove();
+    }
+
+    @Override
+    public boolean isMouseGrabbed() {
+        return super.isMouseGrabbed();
+    }
+
+    @Override
+    public void grabMouse() {
+        if (!Controllable.getOptions().isVirtualMouse())
+            super.grabMouse();
+        else
+            ObfuscationReflectionHelper.setPrivateValue(MouseHelper.class, oldHelper, true, "mouseGrabbed");
+
+    }
+
+    @Override
+    public void ungrabMouse() {
+        if (!Controllable.getOptions().isVirtualMouse())
+            super.grabMouse();
+        else
+            ObfuscationReflectionHelper.setPrivateValue(MouseHelper.class, oldHelper, false, "mouseGrabbed");
+    }
+}

--- a/src/main/java/com/mrcrayfish/controllable/client/settings/ControllerOptions.java
+++ b/src/main/java/com/mrcrayfish/controllable/client/settings/ControllerOptions.java
@@ -3,6 +3,7 @@ package com.mrcrayfish.controllable.client.settings;
 import com.google.common.base.Charsets;
 import com.google.common.base.Splitter;
 import com.mrcrayfish.controllable.Controllable;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.client.settings.BooleanOption;
 import net.minecraft.client.settings.SliderPercentageOption;
@@ -39,6 +40,10 @@ public class ControllerOptions
         return Controllable.getOptions().virtualMouse;
     }, (gameSettings, value) -> {
         Controllable.getOptions().virtualMouse = value;
+
+        Minecraft mc = Minecraft.getInstance();
+        mc.gameSettings.pauseOnLostFocus = !value;
+        mc.gameSettings.saveOptions();
     });
 
     public static final SliderPercentageOption DEAD_ZONE = new ControllableSliderPercentageOption("controllable.options.deadZone", 0.0, 1.0, 0.01F, gameSettings -> {


### PR DESCRIPTION
This fix prevent Minecraft from moving the hardware cursor when virtual mouse is enabled;
It also automatically prevents pausing if the game isn't focused